### PR TITLE
44-codebase-add-windows-phpunit-testing-to-ci

### DIFF
--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -1,6 +1,7 @@
 name: PHPUnit Tests for Moodle Homework Plugin
 
 on:
+  workflow_dispatch:
   push:
     branches: [ "main" ]
     paths:


### PR DESCRIPTION
This pull request adds Windows PHPUnit testing to GitHub Actions CI. 